### PR TITLE
refactor: add robust json parsing utility

### DIFF
--- a/src/tools/json.ts
+++ b/src/tools/json.ts
@@ -1,0 +1,27 @@
+export function extractJson(text: string): unknown | null {
+  if (!text) return null;
+
+  const jsonFence = '```json';
+  const fence = '```';
+  let start = text.indexOf(jsonFence);
+  if (start !== -1) {
+    start += jsonFence.length;
+  } else {
+    start = text.indexOf(fence);
+    if (start !== -1) {
+      start += fence.length;
+    }
+  }
+
+  let jsonString = text;
+  if (start !== -1) {
+    const end = text.indexOf(fence, start);
+    jsonString = end !== -1 ? text.slice(start, end) : text.slice(start);
+  }
+
+  try {
+    return JSON.parse(jsonString.trim());
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `extractJson` helper to locate JSON blocks in text
- integrate helper into business, DM, and market research agents
- log truncated responses when parsing fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 252 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6892675f8d688325bd933dea2b83ae0b