### PR TITLE
feat: map personas via realtime listener

### DIFF
--- a/src/tools/persona-mapper.ts
+++ b/src/tools/persona-mapper.ts
@@ -1,44 +1,53 @@
+import { supa } from '../agents/clients';
+import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
+
 /**
- * Maps businesses to personas once both are available
- * This runs after business discovery and persona generation complete
+ * Maps any businesses without a persona assignment to the available personas.
+ *
+ * When called repeatedly this function will only operate on businesses that
+ * have not yet been mapped (persona_id is null) which enables incremental
+ * updates as new businesses arrive.
  */
-export async function mapBusinessesToPersonas(searchId: string) {
+export async function mapBusinessesToPersonas(searchId: string, businessId?: string) {
   try {
     console.log(`Starting persona mapping for search ${searchId}`);
-    
-    // Get all businesses without proper persona mapping
-    const { data: businesses, error: businessError } = await supa
+
+    // Only load businesses that don't yet have a persona mapping. Optionally
+    // limit to a single business when an id is provided.
+    const businessQuery = supa
       .from('businesses')
       .select('*')
       .eq('search_id', searchId)
       .is('persona_id', null);
-    
+    if (businessId) businessQuery.eq('id', businessId);
+    const { data: businesses, error: businessError } = await businessQuery;
+
     if (businessError) throw businessError;
     if (!businesses || businesses.length === 0) {
       console.log('No businesses found requiring persona mapping');
       return;
     }
-    
+
     // Get all personas for this search
     const { data: personas, error: personaError } = await supa
       .from('business_personas')
       .select('*')
       .eq('search_id', searchId)
       .order('rank');
-    
+
     if (personaError) throw personaError;
     if (!personas || personas.length === 0) {
       console.log('No personas available yet for mapping');
       return;
     }
-    
+
     console.log(`Mapping ${businesses.length} businesses to ${personas.length} personas`);
-    
+
     // Simple mapping logic: distribute businesses across personas based on match criteria
     const updates = businesses.map((business, index) => {
       // Use round-robin distribution for now, but could be enhanced with AI matching
       const persona = personas[index % personas.length];
-      
+
       return supa
         .from('businesses')
         .update({
@@ -49,19 +58,50 @@ export async function mapBusinessesToPersonas(searchId: string) {
         })
         .eq('id', business.id);
     });
-    
+
     // Execute all updates in parallel
     const results = await Promise.allSettled(updates);
     const successful = results.filter(r => r.status === 'fulfilled').length;
     const failed = results.filter(r => r.status === 'rejected').length;
-    
+
     console.log(`Persona mapping completed: ${successful} successful, ${failed} failed`);
-    
+
     return { successful, failed, total: businesses.length };
   } catch (error) {
     console.error('Error mapping businesses to personas:', error);
     throw error;
   }
+}
+
+/**
+ * Starts a Supabase realtime listener that maps businesses to personas whenever
+ * a new business row is inserted for the given search.
+ *
+ * Returns a cleanup function that should be awaited to unsubscribe from the
+ * realtime channel when work is complete.
+ */
+export function startPersonaMappingListener(searchId: string) {
+  const channel = supa
+    .channel(`persona-mapper-${searchId}`)
+    .on(
+      'postgres_changes',
+      {
+        event: 'INSERT',
+        schema: 'public',
+        table: 'businesses',
+        filter: `search_id=eq.${searchId}`
+      },
+      (payload: RealtimePostgresChangesPayload<{ id: string }>) => {
+        mapBusinessesToPersonas(searchId, payload.new.id).catch(err =>
+          console.error('Error mapping persona for new business:', err)
+        );
+      }
+    )
+    .subscribe();
+
+  return async () => {
+    await supa.removeChannel(channel);
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- add Supabase realtime listener to map new businesses to personas as they arrive
- update persona mapper to only process unmapped businesses and allow single-business mapping
- orchestrator now starts/stops listener instead of running mapping after discovery

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 291 problems (279 errors, 12 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6894c8d234148325ac8e80b84357f125