### PR TITLE
Track decision maker discovery progress

### DIFF
--- a/src/agents/business-discovery.agent.ts
+++ b/src/agents/business-discovery.agent.ts
@@ -3,7 +3,7 @@ import { serperPlaces } from '../tools/serper';
 import { insertBusinesses, updateSearchProgress, logApiUsage } from '../tools/db.write';
 
 import { countryToGL, buildBusinessData } from '../tools/util';
-import { triggerInstantDMDiscovery, processBusinessForDM } from '../tools/instant-dm-discovery';
+import { triggerInstantDMDiscovery, processBusinessForDM, initDMDiscoveryProgress } from '../tools/instant-dm-discovery';
 import type { Business } from '../tools/instant-dm-discovery';
 
 const serperPlacesTool = tool({
@@ -181,6 +181,7 @@ const storeBusinessesTool = tool({
     }));
     console.log(`Inserting ${rows.length} businesses for search ${search_id}`);
     const insertedBusinesses = await insertBusinesses(rows);
+    initDMDiscoveryProgress(search_id, insertedBusinesses.length);
     // 🚀 INSTANT DM DISCOVERY: Trigger DM search for each business immediately as it is inserted
     const triggeredBusinessIds = new Set<string>();
     await Promise.all(

--- a/src/agents/dm-discovery-individual.agent.ts
+++ b/src/agents/dm-discovery-individual.agent.ts
@@ -1,6 +1,6 @@
 import { Agent, tool, run } from '@openai/agents';
 import { serperSearch } from '../tools/serper';
-import { insertDecisionMakersBasic, logApiUsage, updateSearchProgress } from '../tools/db.write';
+import { insertDecisionMakersBasic, logApiUsage } from '../tools/db.write';
 import { loadDMPersonas } from '../tools/db.read';
 import { buildDMData, mapDMToPersona } from '../tools/util';
 
@@ -259,7 +259,6 @@ export async function runDMDiscoveryForBusiness(params: {
   business_name: string;
   company_country: string;
   industry: string;
-  skipProgressUpdate?: boolean;
 }) {
   // Ensure DM personas are available before running discovery
   await waitForPersonas(params.search_id);
@@ -276,9 +275,6 @@ User ID: ${params.user_id}
 Search LinkedIn for executives and decision makers, then store them with smart persona mapping.`;
 
   const result = await run(DMDiscoveryIndividualAgent, message);
-  if (!params.skipProgressUpdate) {
-    await updateSearchProgress(params.search_id, 100, 'decision_makers');
-  }
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Track total and processed businesses during decision maker discovery
- Calculate progress percentage from processed/total and update search progress accordingly
- Initialize progress tracking during business discovery and remove per-business 100% updates

## Testing
- `npm run lint` *(fails: Unexpected any/no-unused-vars errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d2cebcbc8325bdb6880be849fa9d