### PR TITLE
fix: accumulate dm discovery totals

### DIFF
--- a/src/agents/business-discovery.agent.ts
+++ b/src/agents/business-discovery.agent.ts
@@ -181,7 +181,10 @@ const storeBusinessesTool = tool({
     }));
     console.log(`Inserting ${rows.length} businesses for search ${search_id}`);
     const insertedBusinesses = await insertBusinesses(rows);
-    initDMDiscoveryProgress(search_id, insertedBusinesses.length);
+    if (insertedBusinesses.length > 0) {
+      // Add this batch to the running DM discovery total
+      initDMDiscoveryProgress(search_id, insertedBusinesses.length);
+    }
     // 🚀 INSTANT DM DISCOVERY: Trigger DM search for each business immediately as it is inserted
     const triggeredBusinessIds = new Set<string>();
     await Promise.all(

--- a/src/tools/instant-dm-discovery.ts
+++ b/src/tools/instant-dm-discovery.ts
@@ -5,7 +5,11 @@ import { updateSearchProgress } from './db.write';
 const dmProgress: Record<string, { total: number; processed: number }> = {};
 
 export function initDMDiscoveryProgress(search_id: string, total: number) {
-  dmProgress[search_id] = { total, processed: 0 };
+  if (dmProgress[search_id]) {
+    dmProgress[search_id].total += total;
+  } else {
+    dmProgress[search_id] = { total, processed: 0 };
+  }
 }
 
 async function recordProgress(search_id: string) {


### PR DESCRIPTION
## Summary
- accumulate DM discovery totals across multiple `storeBusinesses` calls
- update `storeBusinesses` to add each batch to running DM discovery total

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894daa2d2f08325b64804e25808b190