### PR TITLE
Accumulate DM discovery totals across batches

### DIFF
--- a/src/agents/business-discovery.agent.ts
+++ b/src/agents/business-discovery.agent.ts
@@ -181,10 +181,8 @@ const storeBusinessesTool = tool({
     }));
     console.log(`Inserting ${rows.length} businesses for search ${search_id}`);
     const insertedBusinesses = await insertBusinesses(rows);
-    if (insertedBusinesses.length > 0) {
-      // Add this batch to the running DM discovery total
-      initDMDiscoveryProgress(search_id, insertedBusinesses.length);
-    }
+    // Increment the running DM discovery total with this batch
+    initDMDiscoveryProgress(search_id, insertedBusinesses.length);
     // 🚀 INSTANT DM DISCOVERY: Trigger DM search for each business immediately as it is inserted
     const triggeredBusinessIds = new Set<string>();
     await Promise.all(

--- a/src/tools/instant-dm-discovery.ts
+++ b/src/tools/instant-dm-discovery.ts
@@ -5,8 +5,9 @@ import { updateSearchProgress } from './db.write';
 const dmProgress: Record<string, { total: number; processed: number }> = {};
 
 export function initDMDiscoveryProgress(search_id: string, total: number) {
-  if (dmProgress[search_id]) {
-    dmProgress[search_id].total += total;
+  const progress = dmProgress[search_id];
+  if (progress) {
+    progress.total += total;
   } else {
     dmProgress[search_id] = { total, processed: 0 };
   }
@@ -34,9 +35,7 @@ export async function triggerInstantDMDiscovery(
   businesses: Business[]
 ) {
   console.log(`🎯 Starting instant DM discovery for ${businesses.length} businesses`);
-  if (!dmProgress[search_id]) {
-    initDMDiscoveryProgress(search_id, businesses.length);
-  }
+  initDMDiscoveryProgress(search_id, businesses.length);
 
   // Process businesses in small batches to avoid overwhelming the system
   const batchSize = 3;


### PR DESCRIPTION
## Summary
- Ensure DM discovery progress accumulates per search rather than resetting
- Always initialize DM discovery tracking on new batches
- Increment progress totals from each storeBusinesses batch for accurate reporting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894dc6d0d148325940137010848b99e