### PR TITLE
feat: fire-and-forget DM enrichment trigger

### DIFF
--- a/src/agents/dm-discovery-individual.agent.ts
+++ b/src/agents/dm-discovery-individual.agent.ts
@@ -255,11 +255,13 @@ const storeDMsTool = tool({
     }
 
     try {
-      // Trigger backend enrichment via Netlify function
-      await fetch(enrichUrl, {
+      // Trigger backend enrichment via Netlify function without blocking
+      void fetch(enrichUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ search_id })
+      }).catch(err => {
+        console.error('Failed to trigger enrichment:', err);
       });
     } catch (err) {
       console.error('Failed to trigger enrichment:', err);


### PR DESCRIPTION
## Summary
- invoke DM enrichment endpoint once using non-blocking `fetch`
- log enrichment errors without halting DM storage

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894de0364888325813242d207a0463f