### PR TITLE
feat: validate required env vars at startup

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { validateEnv } from './tools/env';
+
+validateEnv();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/tools/env.ts
+++ b/src/tools/env.ts
@@ -1,0 +1,33 @@
+const REQUIRED_ENV_VARS = [
+  'VITE_SUPABASE_URL',
+  'VITE_SUPABASE_ANON_KEY'
+] as const;
+
+type EnvKey = typeof REQUIRED_ENV_VARS[number];
+
+function readEnv(key: string): string | undefined {
+  if (typeof process !== 'undefined' && (process as any)?.env?.[key]) {
+    return (process as any).env[key];
+  }
+  try {
+    return (import.meta as any)?.env?.[key];
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Validate that all required environment variables are present.
+ * Throws an error listing missing keys to prevent partial runtime failures.
+ */
+export function validateEnv(keys: EnvKey[] = REQUIRED_ENV_VARS as unknown as EnvKey[]): void {
+  const missing = keys.filter(key => {
+    const value = readEnv(key);
+    return value === undefined || String(value).trim() === '';
+  });
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+}
+
+export default validateEnv;


### PR DESCRIPTION
## Summary
- add `validateEnv` helper to ensure required environment variables are present
- invoke `validateEnv` during app bootstrap

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c746b2b8083258d4b6622036ff47f