### PR TITLE
feat: enrich market insight sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ npm run typecheck
 ### Database (Supabase)
 - Canonical SQLs: `complete_database_setup_fixed.sql`, `fix_authentication_and_database.sql`, `fix_proxy_authentication.sql`, `fix_rls_policies.sql`.
 - RLS policies support read flows via proxy; server functions use service role for writes.
+- `market_insights.sources` now stores objects `{ title, url, date }` for richer citation metadata.
 
 ### Security & privacy
 - No secrets in client bundles; write operations occur only in functions.

--- a/complete_database_setup.sql
+++ b/complete_database_setup.sql
@@ -44,8 +44,8 @@ ADD COLUMN IF NOT EXISTS address text DEFAULT '',
 ADD COLUMN IF NOT EXISTS rating decimal(2,1) DEFAULT null;
 
 -- 4. Fix market_insights table for comprehensive market research
-ALTER TABLE market_insights 
-ADD COLUMN IF NOT EXISTS sources jsonb DEFAULT '[]',
+ALTER TABLE market_insights
+ADD COLUMN IF NOT EXISTS sources jsonb DEFAULT '[]', -- [{title,text,url,text,date,text}]
 ADD COLUMN IF NOT EXISTS analysis_summary text DEFAULT '',
 ADD COLUMN IF NOT EXISTS research_methodology text DEFAULT '';
 

--- a/complete_database_setup_fixed.sql
+++ b/complete_database_setup_fixed.sql
@@ -44,8 +44,8 @@ ADD COLUMN IF NOT EXISTS address text DEFAULT '',
 ADD COLUMN IF NOT EXISTS rating decimal(2,1) DEFAULT null;
 
 -- 4. Fix market_insights table for comprehensive market research
-ALTER TABLE market_insights 
-ADD COLUMN IF NOT EXISTS sources jsonb DEFAULT '[]',
+ALTER TABLE market_insights
+ADD COLUMN IF NOT EXISTS sources jsonb DEFAULT '[]', -- [{title,text,url,text,date,text}]
 ADD COLUMN IF NOT EXISTS analysis_summary text DEFAULT '',
 ADD COLUMN IF NOT EXISTS research_methodology text DEFAULT '';
 

--- a/database_fixes.sql
+++ b/database_fixes.sql
@@ -3,8 +3,8 @@
 -- =====================================================
 
 -- 1. FIX MARKET_INSIGHTS TABLE - Add missing columns
-ALTER TABLE market_insights 
-ADD COLUMN IF NOT EXISTS sources jsonb DEFAULT '[]',
+ALTER TABLE market_insights
+ADD COLUMN IF NOT EXISTS sources jsonb DEFAULT '[]', -- [{title,text,url,text,date,text}]
 ADD COLUMN IF NOT EXISTS analysis_summary text DEFAULT '',
 ADD COLUMN IF NOT EXISTS research_methodology text DEFAULT '',
 ADD COLUMN IF NOT EXISTS raw_analysis text DEFAULT '';

--- a/database_fixes_simple.sql
+++ b/database_fixes_simple.sql
@@ -4,8 +4,8 @@
 -- =====================================================
 
 -- STEP 1: Fix market_insights table (CRITICAL for market research)
-ALTER TABLE market_insights 
-ADD COLUMN IF NOT EXISTS sources jsonb DEFAULT '[]';
+ALTER TABLE market_insights
+ADD COLUMN IF NOT EXISTS sources jsonb DEFAULT '[]'; -- [{title,text,url,text,date,text}]
 
 ALTER TABLE market_insights 
 ADD COLUMN IF NOT EXISTS analysis_summary text DEFAULT '';

--- a/src/agents/market-research.agent.ts
+++ b/src/agents/market-research.agent.ts
@@ -199,7 +199,9 @@ OUTPUT JSON SCHEMA EXACTLY:
         competitor_data: data.competitor_data || [],
         trends: data.trends || [],
         opportunities: data.opportunities || {},
-        sources: (data.sources && Array.isArray(data.sources)) ? data.sources : sources.map(s => s.url),
+        sources: Array.isArray(data.sources) && data.sources.length
+          ? data.sources.map((s: any) => typeof s === 'string' ? { title: s, url: s } : s)
+          : sources.map(({ title, url }) => ({ title, url })),
         analysis_summary: data.analysis_summary || 'Market research completed using OpenAI GPT-5 analysis',
         research_methodology: data.research_methodology || 'AI-assisted market analysis grounded in recent web sources and country/industry context'
       };

--- a/src/tools/db.write.ts
+++ b/src/tools/db.write.ts
@@ -153,6 +153,13 @@ export const insertDecisionMakersBasic = async (rows: any[]) => {
 
 // Update enrichment data for a specific decision maker - moved to end of file
 
+type InsightSource = {
+  title?: string;
+  url: string;
+  date?: string;
+  [key: string]: any;
+};
+
 export const insertMarketInsights = async (row: {
   search_id: string;
   user_id: string;
@@ -162,12 +169,16 @@ export const insertMarketInsights = async (row: {
   competitor_data: any[];
   trends: any[];
   opportunities: any;
-  sources?: any[];
+  sources?: InsightSource[];
   analysis_summary?: string;
   research_methodology?: string;
 }) => {
   const supa = getSupabaseClient();
-  const { data, error } = await supa.from('market_insights').insert(row).select('id').single();
+  const sources = (row.sources || []).map((s: any) => {
+    if (typeof s === 'string') return { title: s, url: s } as InsightSource;
+    return { title: s.title ?? s.url, url: s.url, date: s.date, ...s } as InsightSource;
+  });
+  const { data, error } = await supa.from('market_insights').insert({ ...row, sources }).select('id').single();
   if (error) throw error;
   try { await updateSearchTotals(row.search_id); } catch (e: any) { logger.warn('updateSearchTotals failed', { error: e?.message || e }); }
   return data!;


### PR DESCRIPTION
## Summary
- normalize fallback market research sources to objects with title and url
- allow insertMarketInsights to store source title and date metadata
- document sources schema in SQL setup files and README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c7467be288325bb02d72cb76b8b6c