### PR TITLE
Use Supabase to dedupe LinkedIn search queries

### DIFF
--- a/add_linkedin_query_log.sql
+++ b/add_linkedin_query_log.sql
@@ -1,0 +1,11 @@
+-- Create table for logging LinkedIn search queries to avoid duplicates
+CREATE TABLE IF NOT EXISTS linkedin_query_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  hash text NOT NULL UNIQUE,
+  company text NOT NULL,
+  query text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Periodic cleanup (run separately):
+-- DELETE FROM linkedin_query_log WHERE created_at < now() - interval '30 days';

--- a/src/agents/dm-discovery-individual.agent.ts
+++ b/src/agents/dm-discovery-individual.agent.ts
@@ -6,6 +6,7 @@ import { loadDMPersonas } from '../tools/db.read';
 import { mapDMToPersona } from '../tools/util';
 import logger from '../lib/logger';
 import { mapDecisionMakersToPersonas } from '../tools/persona-mapper';
+import { createHash } from 'crypto';
 
 interface Employee {
   name: string;
@@ -22,18 +23,52 @@ interface Employee {
 
 type SerperItem = { link?: string; title?: string; snippet?: string };
 
-// Simple in-memory de-duplication of repeated search queries across invocations
-const seenQueries = new Set<string>();
-function hasSeen(company: string, query: string) {
-  const key = `${company}::${query}`.toLowerCase();
-  return seenQueries.has(key);
+// Supabase-backed de-duplication of repeated search queries
+const QUERY_LOG_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const supa = sharedSupa;
+
+function makeQueryHash(company: string, query: string): string {
+  return createHash('sha256').update(`${company}::${query}`.toLowerCase()).digest('hex');
 }
-function markSeen(company: string, query: string) {
-  const key = `${company}::${query}`.toLowerCase();
-  if (seenQueries.size > 5000) {
-    seenQueries.clear();
+
+async function hasSeen(company: string, query: string): Promise<boolean> {
+  const hash = makeQueryHash(company, query);
+  const cutoff = new Date(Date.now() - QUERY_LOG_TTL_MS).toISOString();
+  try {
+    const { data, error } = await supa
+      .from('linkedin_query_log')
+      .select('id')
+      .eq('hash', hash)
+      .gte('created_at', cutoff)
+      .limit(1)
+      .maybeSingle();
+    if (error) {
+      logger.warn('Failed to check query log', { error: error.message || error });
+      return false;
+    }
+    return Boolean(data);
+  } catch (e: any) {
+    logger.warn('Failed to check query log', { error: e?.message || e });
+    return false;
   }
-  seenQueries.add(key);
+}
+
+async function markSeen(company: string, query: string): Promise<void> {
+  const hash = makeQueryHash(company, query);
+  try {
+    await supa.from('linkedin_query_log').insert({ hash, company, query }).select('id');
+  } catch (e: any) {
+    logger.warn('Failed to log query', { error: e?.message || e });
+  }
+}
+
+async function expireOldQueryLogs(): Promise<void> {
+  const cutoff = new Date(Date.now() - QUERY_LOG_TTL_MS).toISOString();
+  try {
+    await supa.from('linkedin_query_log').delete().lt('created_at', cutoff);
+  } catch (e: any) {
+    logger.warn('Failed to expire old query logs', { error: e?.message || e });
+  }
 }
 
 const linkedinSearchTool = tool({
@@ -62,8 +97,10 @@ const linkedinSearchTool = tool({
     };
     
     const startTime = Date.now();
-    
+
     try {
+      await expireOldQueryLogs();
+
       // Single precise search per company to limit API usage
       const personas = await loadDMPersonas(search_id);
       const primaryTitle = (Array.isArray(personas) && personas[0]?.title) ? String(personas[0].title).trim() : 'Head of';
@@ -76,8 +113,8 @@ const linkedinSearchTool = tool({
       // Search for employees in different roles
       for (const query of queries) {
         try {
-          // Skip if we've already executed this query for this company in this process
-          if (hasSeen(company_name, query)) {
+          // Skip if we've already executed this query recently
+          if (await hasSeen(company_name, query)) {
             continue;
           }
           const result = await serperSearch(query, company_country, 10);
@@ -114,7 +151,7 @@ const linkedinSearchTool = tool({
             allEmployees.push(...employees);
           }
           // Mark this query as seen to prevent future duplicates
-          markSeen(company_name, query);
+          await markSeen(company_name, query);
           
           // Small delay between searches to avoid rate limiting
           const jitter = 300 + Math.floor(Math.random() * 300);


### PR DESCRIPTION
## Summary
- Replace in-memory LinkedIn query tracking with Supabase `linkedin_query_log` table using SHA-256 hashes
- Skip searches when a company/query hash already exists and log new hashes after each search
- Add SQL schema and cleanup guidance for the new `linkedin_query_log` table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c7464b48c8325b04bfe13b43c024c