### PR TITLE
feat: add optional advanced market research

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Leadora is a production‑grade, zero‑console, fully serverless multi‑agent 
 - Business Discovery (Serper Places/Search + CSE fallback), country‑aware, with conservative filtering.
 - Decision‑Maker Discovery + server‑side Contact Enrichment (email/phone) with graceful backoff.
 - Market Research (GPT‑5 primary) with multi‑country web references, structured JSON output (TAM/SAM/SOM, competitors, trends).
+- Optional advanced market research with live web search and TAM/SAM/SOM, competitor, and trend analysis when `use_advanced_research` is set on a search record.
 - Real‑time UI progress via SSE and Supabase listeners; data persists in Supabase (RLS compatible).
 
 ### Architecture


### PR DESCRIPTION
## Summary
- trigger advanced market research when `use_advanced_research` flag is set
- add advanced market research wrapper to collect and store market insights
- document the `use_advanced_research` flag

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c74ad111c83259da0b0495f78ff00