### PR TITLE
Refactor orchestration task tracking

### DIFF
--- a/src/orchestration/orchestrate.ts
+++ b/src/orchestration/orchestrate.ts
@@ -25,75 +25,93 @@ export async function orchestrate(search_id: string, _user_id: string, sendUpdat
     // Weight-based progress reporting
     const weights = { business_personas: 10, dm_personas: 10, business_discovery: 40, market_research: 20 } as const;
     let currentProgress = 20;
-    let chain = Promise.resolve();
-    const reportProgress = (weight: number, phase: keyof typeof weights) => {
-      chain = chain.then(async () => {
-        currentProgress += weight;
-        await updateSearchProgress(search_id, currentProgress, phase, 'in_progress');
-        updateFn('PROGRESS', { phase, progress: currentProgress });
-      });
-      return chain;
-    };
-
-    // Shared status map for status_detail
-    const statusMap: Record<string, 'done' | 'failed'> = {};
+    const taskStatus: Record<string, 'done' | 'failed'> = {};
     const recordStatus = async (agent: string, outcome: 'done' | 'failed') => {
-      statusMap[agent] = outcome;
+      taskStatus[agent] = outcome;
       try {
-        await updateSearchProgress(search_id, currentProgress, 'starting', 'in_progress', statusMap);
+        await updateSearchProgress(search_id, currentProgress, 'starting', 'in_progress', taskStatus);
       } catch (err: any) {
         logger.warn('Failed to update status_detail', { error: err?.message || err });
       }
+    };
+    const reportProgress = async (weight: number, phase: keyof typeof weights) => {
+      currentProgress += weight;
+      await updateSearchProgress(search_id, currentProgress, phase, 'in_progress');
+      updateFn('PROGRESS', { phase, progress: currentProgress });
     };
 
     await updateSearchProgress(search_id, 20, 'starting', 'in_progress');
     updateFn('PROGRESS', { phase: 'starting', progress: 20 });
 
     // Parallel task executions
-    const parallelTasks = [
-      runBusinessPersonas(search)
-        .then(async () => { updateFn('PERSONAS_READY', { type: 'business', search_id }); await recordStatus('business_personas', 'done'); return 'business_personas_done'; })
-        .catch(async (err) => { logger.warn('Business personas failed', { error: err?.message || err }); await recordStatus('business_personas', 'failed'); return 'business_personas_failed'; })
-        .finally(() => reportProgress(weights.business_personas, 'business_personas')),
-
-      runDMPersonas(search)
-        .then(async () => { updateFn('PERSONAS_READY', { type: 'dm', search_id }); await recordStatus('dm_personas', 'done'); return 'dm_personas_done'; })
-        .catch(async (err) => { logger.warn('DM personas failed', { error: err?.message || err }); await recordStatus('dm_personas', 'failed'); return 'dm_personas_failed'; })
-        .finally(() => reportProgress(weights.dm_personas, 'dm_personas')),
-
-      runBusinessDiscovery(search)
-        .then(async () => { updateFn('BUSINESSES_FOUND', { search_id }); await recordStatus('business_discovery', 'done'); return 'business_discovery_done'; })
-        .catch(async (err) => { logger.warn('Business discovery failed', { error: err?.message || err }); await recordStatus('business_discovery', 'failed'); return 'business_discovery_failed'; })
-        .finally(() => reportProgress(weights.business_discovery, 'business_discovery')),
-
-      marketResearchTask(search)
-        .then(async () => { updateFn('MARKET_RESEARCH_READY', { search_id }); await recordStatus('market_research', 'done'); return 'market_research_done'; })
-        .catch(async (err) => { logger.warn('Market research failed', { error: err?.message || err }); await mergeAgentMetadata(search_id, { market_research_warning: true }); await recordStatus('market_research', 'failed'); return 'market_research_failed'; })
-        .finally(() => reportProgress(weights.market_research, 'market_research')),
+    const tasks = [
+      {
+        key: 'business_personas',
+        weight: weights.business_personas,
+        phase: 'business_personas' as const,
+        run: () => runBusinessPersonas(search),
+        onSuccess: () => updateFn('PERSONAS_READY', { type: 'business', search_id }),
+      },
+      {
+        key: 'dm_personas',
+        weight: weights.dm_personas,
+        phase: 'dm_personas' as const,
+        run: () => runDMPersonas(search),
+        onSuccess: () => updateFn('PERSONAS_READY', { type: 'dm', search_id }),
+      },
+      {
+        key: 'business_discovery',
+        weight: weights.business_discovery,
+        phase: 'business_discovery' as const,
+        run: () => runBusinessDiscovery(search),
+        onSuccess: () => updateFn('BUSINESSES_FOUND', { search_id }),
+      },
+      {
+        key: 'market_research',
+        weight: weights.market_research,
+        phase: 'market_research' as const,
+        run: () => marketResearchTask(search),
+        onSuccess: () => updateFn('MARKET_RESEARCH_READY', { search_id }),
+        onError: () => mergeAgentMetadata(search_id, { market_research_warning: true }),
+      },
     ];
 
-    const results = await Promise.allSettled(parallelTasks);
-    results.forEach((result, index) => {
-      const taskNames = ['Business Personas', 'DM Personas', 'Business Discovery', useAdvancedResearch ? 'Advanced Market Research' : 'Market Research'];
-      if (result.status === 'fulfilled') {
-        logger.debug(`${taskNames[index]} finished`, { result: result.value });
-      } else {
-        logger.warn(`${taskNames[index]} failed`, { error: (result as any).reason });
-      }
-    });
+    const parallelTasks = tasks.map(t =>
+      t
+        .run()
+        .then(async () => { t.onSuccess?.(); await recordStatus(t.key, 'done'); })
+        .catch(async (err) => {
+          logger.warn(`${t.key} failed`, { error: err?.message || err });
+          await t.onError?.();
+          await recordStatus(t.key, 'failed');
+        })
+    );
 
-    const anySuccess = Object.values(statusMap).some(s => s === 'done');
-    const allFailed = Object.keys(statusMap).length > 0 && Object.values(statusMap).every(s => s === 'failed');
-    if (!allFailed && anySuccess) {
-      await updateSearchProgress(search_id, 100, 'completed', 'completed', statusMap);
+    const results = await Promise.allSettled(parallelTasks);
+
+    for (let i = 0; i < tasks.length; i++) {
+      const task = tasks[i];
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        logger.debug(`${task.key} finished`, { result: result.value });
+      } else {
+        logger.warn(`${task.key} failed`, { error: (result as any).reason });
+      }
+      await reportProgress(task.weight, task.phase);
+    }
+
+    const essentialTasks = ['business_personas', 'dm_personas', 'business_discovery'] as const;
+    const allEssentialSucceeded = essentialTasks.every(t => taskStatus[t] === 'done');
+    if (allEssentialSucceeded) {
+      await updateSearchProgress(search_id, 100, 'completed', 'completed', taskStatus);
       updateFn('PROGRESS', { phase: 'completed', progress: 100 });
     } else {
-      await updateSearchProgress(search_id, 0, 'failed', 'failed', statusMap);
-      updateFn('ERROR', { search_id, message: 'All parallel tasks failed' });
+      await updateSearchProgress(search_id, 0, 'failed', 'failed', taskStatus);
+      updateFn('ERROR', { search_id, message: 'One or more essential tasks failed' });
     }
 
     logger.info('Optimized orchestration finished', { search_id });
-    return { success: true, search_id, results: statusMap };
+    return { success: allEssentialSucceeded, search_id, results: taskStatus };
   } catch (error: any) {
     logger.error('Orchestration failed', { search_id, error: error?.message || error });
     try {


### PR DESCRIPTION
## Summary
- centralize task status tracking with `taskStatus` map and `recordStatus` helper
- consolidate parallel tasks and remove duplicate persona runs
- update progress and final status only after all essential tasks finish

## Testing
- `npm test` *(fails: No test suite found in file src/tools/persona-validation.test.ts)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d0b6cda108325a67bab5c93522c85