### PR TITLE
Fix lint warnings and stabilize market insights state

### DIFF
--- a/netlify/functions/user-data-proxy.ts
+++ b/netlify/functions/user-data-proxy.ts
@@ -2,7 +2,6 @@ import type { Handler } from '@netlify/functions';
 const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY || '';
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_SERVICE_ROLE_KEY || '';
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || '').split(',').map(s => s.trim()).filter(Boolean);
 
 function buildCorsHeaders(origin?: string, requestHeaders?: string, requestMethod?: string) {
   const allowHeaders = (requestHeaders && requestHeaders.length > 0)

--- a/src/components/modules/MarketingInsights.tsx
+++ b/src/components/modules/MarketingInsights.tsx
@@ -56,17 +56,25 @@ export default function MarketingInsights() {
     return v;
   };
   // Use real-time data for real users, demo data for demo users
-  const marketRowRaw = isDemo ? demoMarketData : (realTimeData.marketInsights.length > 0 ? realTimeData.marketInsights[0] : null);
-  const marketRow: any = marketRowRaw ? {
-    ...marketRowRaw,
-    tam_data: parseMaybeJSON((marketRowRaw as any).tam_data),
-    sam_data: parseMaybeJSON((marketRowRaw as any).sam_data),
-    som_data: parseMaybeJSON((marketRowRaw as any).som_data),
-    competitor_data: parseMaybeJSON((marketRowRaw as any).competitor_data),
-    trends: parseMaybeJSON((marketRowRaw as any).trends),
-    opportunities: parseMaybeJSON((marketRowRaw as any).opportunities),
-    sources: parseMaybeJSON((marketRowRaw as any).sources)
-  } : null;
+  const marketRowRaw = useMemo(() => {
+    return isDemo
+      ? demoMarketData
+      : (realTimeData.marketInsights.length > 0 ? realTimeData.marketInsights[0] : null);
+  }, [isDemo, demoMarketData, realTimeData.marketInsights]);
+
+  const marketRow: any = useMemo(() => {
+    if (!marketRowRaw) return null;
+    return {
+      ...marketRowRaw,
+      tam_data: parseMaybeJSON((marketRowRaw as any).tam_data),
+      sam_data: parseMaybeJSON((marketRowRaw as any).sam_data),
+      som_data: parseMaybeJSON((marketRowRaw as any).som_data),
+      competitor_data: parseMaybeJSON((marketRowRaw as any).competitor_data),
+      trends: parseMaybeJSON((marketRowRaw as any).trends),
+      opportunities: parseMaybeJSON((marketRowRaw as any).opportunities),
+      sources: parseMaybeJSON((marketRowRaw as any).sources)
+    };
+  }, [marketRowRaw]);
   // Derive normalized blocks for rendering (tam/sam/som)
   const marketBlocks = isDemo
     ? (demoMarketData ? { tam: demoMarketData.tam, sam: demoMarketData.sam, som: demoMarketData.som } : null)

--- a/src/orchestration/exec-market-research-parallel.ts
+++ b/src/orchestration/exec-market-research-parallel.ts
@@ -67,7 +67,7 @@ Use these sources when relevant (do not quote text, just use as references):\n${
         request: { model: modelId, product: searchData.product_service, industries: searchData.industries, countries: searchData.countries },
         response: { text_length: analysis.length }
       });
-    } catch (e: any) {
+    } catch {
       // Fallback to Gemini
       provider = 'gemini';
       try {
@@ -83,7 +83,7 @@ Use these sources when relevant (do not quote text, just use as references):\n${
           request: { model: 'gemini-1.5-pro', product: searchData.product_service },
           response: { text_length: analysis.length }
         });
-      } catch (e2: any) {
+      } catch {
         provider = 'fallback';
         analysis = JSON.stringify({
           sources: webFindings.map(s => s.url),

--- a/src/tools/persona-validation.test.ts
+++ b/src/tools/persona-validation.test.ts
@@ -1,4 +1,4 @@
-import { strict as assert } from 'node:assert';
+import { describe, it, expect } from 'vitest';
 import { sanitizePersona, isRealisticPersona } from './persona-validation.ts';
 
 const ctx: { industries: string[]; countries: string[]; search_type: 'customer' } = {
@@ -7,45 +7,50 @@ const ctx: { industries: string[]; countries: string[]; search_type: 'customer' 
   search_type: 'customer'
 };
 
-// Test sanitizePersona for business
-const sanitized = sanitizePersona('business', {}, 0, ctx);
-assert.ok(sanitized.title.includes('Buyer Archetype 1'));
-assert.equal(sanitized.demographics.industry, 'Energy');
-assert.equal(sanitized.locations[0], 'USA');
+describe('persona validation helpers', () => {
+  it('sanitizes business persona data', () => {
+    const sanitized = sanitizePersona('business', {}, 0, ctx);
+    expect(sanitized.title).toContain('Buyer Archetype 1');
+    expect(sanitized.demographics.industry).toBe('Energy');
+    expect(sanitized.locations[0]).toBe('USA');
+  });
 
-// Test generic title detection
-const genericPersona = {
-  title: 'Persona 1',
-  rank: 1,
-  match_score: 90,
-  demographics: { industry: 'Energy', companySize: '100', geography: 'USA', revenue: '$1M' },
-  characteristics: { painPoints: ['a'], motivations: ['b'], challenges: ['c'], decisionFactors: ['d'] },
-  behaviors: { buyingProcess: 'x', decisionTimeline: 'y', budgetRange: 'z', preferredChannels: ['email'] },
-  market_potential: { totalCompanies: 1, avgDealSize: '$1', conversionRate: 1 },
-  locations: ['USA']
-};
-assert.equal(isRealisticPersona('business', genericPersona as any), false);
+  it('detects generic business personas', () => {
+    const genericPersona = {
+      title: 'Persona 1',
+      rank: 1,
+      match_score: 90,
+      demographics: { industry: 'Energy', companySize: '100', geography: 'USA', revenue: '$1M' },
+      characteristics: { painPoints: ['a'], motivations: ['b'], challenges: ['c'], decisionFactors: ['d'] },
+      behaviors: { buyingProcess: 'x', decisionTimeline: 'y', budgetRange: 'z', preferredChannels: ['email'] },
+      market_potential: { totalCompanies: 1, avgDealSize: '$1', conversionRate: 1 },
+      locations: ['USA']
+    } as any;
+    expect(isRealisticPersona('business', genericPersona)).toBe(false);
+  });
 
-// Test missing fields for DM persona
-const incompleteDM: any = {
-  title: 'CTO',
-  rank: 1,
-  match_score: 90,
-  demographics: { level: '', department: '', experience: '', geography: '' },
-  characteristics: { responsibilities: [], painPoints: [], motivations: [], challenges: [], decisionFactors: [] },
-  behaviors: { decisionMaking: '', communicationStyle: '', buyingProcess: '', preferredChannels: [] },
-  market_potential: { totalDecisionMakers: 0, avgInfluence: 0, conversionRate: 0 }
-};
-assert.equal(isRealisticPersona('dm', incompleteDM), false);
+  it('flags incomplete DM personas', () => {
+    const incompleteDM: any = {
+      title: 'CTO',
+      rank: 1,
+      match_score: 90,
+      demographics: { level: '', department: '', experience: '', geography: '' },
+      characteristics: { responsibilities: [], painPoints: [], motivations: [], challenges: [], decisionFactors: [] },
+      behaviors: { decisionMaking: '', communicationStyle: '', buyingProcess: '', preferredChannels: [] },
+      market_potential: { totalDecisionMakers: 0, avgInfluence: 0, conversionRate: 0 }
+    };
+    expect(isRealisticPersona('dm', incompleteDM)).toBe(false);
+  });
 
-// Test generic DM title
-const dmWithGeneric = sanitizePersona('dm', {
-  title: 'Persona Manager',
-  demographics: { level: 'executive', department: 'IT', experience: '10y', geography: 'USA' },
-  characteristics: { responsibilities: ['a'], painPoints: ['b'], motivations: ['c'], challenges: ['d'], decisionFactors: ['e'] },
-  behaviors: { decisionMaking: 'Strategic', communicationStyle: 'Brief', buyingProcess: 'Committee', preferredChannels: ['Demos'] },
-  market_potential: { totalDecisionMakers: 10, avgInfluence: 5, conversionRate: 1 }
-}, 0, ctx);
-assert.equal(isRealisticPersona('dm', dmWithGeneric), false);
+  it('detects generic DM titles', () => {
+    const dmWithGeneric = sanitizePersona('dm', {
+      title: 'Persona Manager',
+      demographics: { level: 'executive', department: 'IT', experience: '10y', geography: 'USA' },
+      characteristics: { responsibilities: ['a'], painPoints: ['b'], motivations: ['c'], challenges: ['d'], decisionFactors: ['e'] },
+      behaviors: { decisionMaking: 'Strategic', communicationStyle: 'Brief', buyingProcess: 'Committee', preferredChannels: ['Demos'] },
+      market_potential: { totalDecisionMakers: 10, avgInfluence: 5, conversionRate: 1 }
+    } as any, 0, ctx);
+    expect(isRealisticPersona('dm', dmWithGeneric)).toBe(false);
+  });
+});
 
-console.log('persona-validation tests passed');


### PR DESCRIPTION
## Summary
- remove unused variable in Netlify proxy handler
- memoize market insights parsing and clean error handling
- add proper persona validation tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d13e153ac83259b02032d15af450f