### PR TITLE
fix: sanitize numeric parsing and cleanup

### DIFF
--- a/src/agents/business-persona.agent.ts
+++ b/src/agents/business-persona.agent.ts
@@ -673,8 +673,6 @@ Return JSON: {"personas": [ {"title": "..."}, {"title": "..."}, {"title": "..."}
       }
       throw new Error('BUSINESS_PERSONAS_FAILED');
     }
-    // Ensure we only update progress once at the end of the routine
-    import('../lib/logger').then(({ default: logger }) => logger.info('Completed business persona generation', { search_id: search.id })).catch(()=>{});
   } catch (error) {
     import('../lib/logger').then(({ default: logger }) => logger.error('Business persona generation failed', { search_id: search.id, error: (error as any)?.message || error })).catch(()=>{});
     throw error;

--- a/src/components/modules/MarketingInsights.tsx
+++ b/src/components/modules/MarketingInsights.tsx
@@ -534,7 +534,11 @@ export default function MarketingInsights() {
                       <div className="absolute inset-0">
                         {(competitorData || []).map((c: any, idx: number) => {
                           const share = clamp(Number(String(c.marketShare).replace(/[^0-9.]/g, '')) || 0);
-                          const growthPct = clamp(Number(String(c.growth || '0').replace(/[^0-9.\-]/g, '')) || 0, -20, 50);
+                          const growthPct = clamp(
+                            Number(String(c.growth || '0').replace(/[^0-9.-]/g, '')) || 0,
+                            -20,
+                            50
+                          );
                           const x = 10 + (share/100) * 85;
                           const y = 50 - ((growthPct + 20) / 70) * 45;
                           const color = palette[idx % palette.length];

--- a/src/tools/persona-validation.ts
+++ b/src/tools/persona-validation.ts
@@ -119,14 +119,14 @@ export function sanitizePersona(
     }
     return [];
   };
-  const coerceNumber = (v: any): number => {
-    if (typeof v === 'number' && Number.isFinite(v)) return v;
-    if (typeof v === 'string') {
-      const n = parseFloat(v.replace(/[^0-9.\-]+/g, ''));
-      return Number.isFinite(n) ? n : 0;
-    }
-    return 0;
-  };
+    const coerceNumber = (v: any): number => {
+      if (typeof v === 'number' && Number.isFinite(v)) return v;
+      if (typeof v === 'string') {
+        const n = parseFloat(v.replace(/[^0-9.-]+/g, ''));
+        return Number.isFinite(n) ? n : 0;
+      }
+      return 0;
+    };
   if (type === 'business') {
     const firstIndustry = Array.isArray((ctx as any)?.industries) && (ctx as any).industries.length ? String((ctx as any).industries[0]) : 'General';
     const firstCountry = Array.isArray((ctx as any)?.countries) && (ctx as any).countries.length ? String((ctx as any).countries[0]) : 'Global';


### PR DESCRIPTION
## Summary
- Sanitize numeric parsing for growth percentages and persona numbers
- Clean up business persona agent logging

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68a21b7d674483259daa622ba6cb9762