### PR TITLE
Ensure business persona fallback always inserts sanitized results

### DIFF
--- a/src/agents/business-persona.agent.ts
+++ b/src/agents/business-persona.agent.ts
@@ -649,29 +649,40 @@ Return JSON: {"personas": [ {"title": "..."}, {"title": "..."}, {"title": "..."}
         acceptedSynthetic = [mk(1), mk(2), mk(3)];
       }
       if (acceptedSynthetic.length === 3) {
-        const accepted = await ensureUniqueTitles<Persona>(acceptedSynthetic, { id: search.id });
-        const allRealistic = accepted.every(p => isRealisticPersona('business', p));
-        const allValid = allRealistic && accepted.every(p => validatePersona(p));
-        if (allValid) {
-          const rows = accepted.map(p => ({
-            search_id: search.id,
-            user_id: search.user_id,
-            title: p.title,
-            rank: p.rank,
-            match_score: p.match_score,
-            demographics: p.demographics || {},
-            characteristics: p.characteristics || {},
-            behaviors: p.behaviors || {},
-            market_potential: p.market_potential || {},
-            locations: p.locations || []
-          }));
-          await insertBusinessPersonas(rows);
-          await updateSearchProgress(search.id, 20, 'business_personas');
-          import('../lib/logger').then(({ default: logger }) => logger.warn('[BusinessPersona] Used heuristic fallback from businesses', { search_id: search.id })).catch(()=>{});
-          return;
+        // Ensure titles are unique and all fields are sanitized before persistence
+        let accepted = await ensureUniqueTitles<Persona>(acceptedSynthetic, { id: search.id });
+        accepted = accepted.map((p, i) => sanitizePersona('business', p, i, search));
+        const realistic = accepted.every(p => isRealisticPersona('business', p));
+        if (!realistic) {
+          // If personas look unrealistic, log but proceed so UI can recover gracefully
+          import('../lib/logger')
+            .then(({ default: logger }) => logger.warn('[BusinessPersona] Fallback personas appeared unrealistic', { search_id: search.id }))
+            .catch(() => {});
         }
+        const rows = accepted.map(p => ({
+          search_id: search.id,
+          user_id: search.user_id,
+          title: p.title,
+          rank: p.rank,
+          match_score: p.match_score,
+          demographics: p.demographics || {},
+          characteristics: p.characteristics || {},
+          behaviors: p.behaviors || {},
+          market_potential: p.market_potential || {},
+          locations: p.locations || []
+        }));
+        await insertBusinessPersonas(rows);
+        await updateSearchProgress(search.id, 20, 'business_personas');
+        import('../lib/logger')
+          .then(({ default: logger }) => logger.warn('[BusinessPersona] Used heuristic fallback from businesses', { search_id: search.id }))
+          .catch(() => {});
+        return;
       }
-      throw new Error('BUSINESS_PERSONAS_FAILED');
+      // If persona synthesis still fails, log and exit without throwing to avoid orchestrator crash
+      import('../lib/logger')
+        .then(({ default: logger }) => logger.error('[BusinessPersona] Failed to synthesize fallback personas', { search_id: search.id }))
+        .catch(() => {});
+      return;
     }
     // Ensure we only update progress once at the end of the routine
     import('../lib/logger').then(({ default: logger }) => logger.info('Completed business persona generation', { search_id: search.id })).catch(()=>{});


### PR DESCRIPTION
## Summary
- Improve business persona agent to sanitize and persist fallback personas instead of throwing errors
- Log when heuristic personas appear unrealistic or synthesis fails

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68a21b7d674483259daa622ba6cb9762